### PR TITLE
Return all matching HWNDs and use first result in moveWindow

### DIFF
--- a/move-window.go
+++ b/move-window.go
@@ -17,21 +17,23 @@ func moveWindow(windowName string, instance int, x int, y int, width int, height
 	bringWindowToTopProc := user32Dll.NewProc("BringWindowToTop")
 	showWindowProc := user32Dll.NewProc("ShowWindow")
 
-	hwnd, err := getHWND(windowName)
+	hwndList, err := getHWNDs(windowName)
 	if err != nil {
 		return err
 	}
 
+	fmt.Println("HWND List:", hwndList)
+
 	fmt.Println("Not using instance:", instance)
 	repaint := 1 // TRUE
 
-	ret, _, err := showWindowProc.Call(hwnd[0], 9)
+	ret, _, err := showWindowProc.Call(hwndList[0], 9)
 	if ret == 0 {
 		return err
 	}
 
 	ret, _, err = moveWindowProc.Call(
-		hwnd[0],
+		hwndList[0],
 		uintptr(x),
 		uintptr(y),
 		uintptr(width),
@@ -42,14 +44,14 @@ func moveWindow(windowName string, instance int, x int, y int, width int, height
 		return err
 	}
 
-	bringWindowToTopProc.Call(hwnd[0])
-	setForegroundWindowProc.Call(hwnd[0])
+	bringWindowToTopProc.Call(hwndList[0])
+	setForegroundWindowProc.Call(hwndList[0])
 
 	fmt.Println("Window restored, moved, resized, and brought to the foreground.")
 	return nil
 }
 
-func getHWND(targetProcessName string) ([]uintptr, error) {
+func getHWNDs(targetProcessName string) ([]uintptr, error) {
 	user32DLL := syscall.NewLazyDLL("user32.dll")
 	kernel32DLL := syscall.NewLazyDLL("kernel32.dll")
 

--- a/move-window.go
+++ b/move-window.go
@@ -25,13 +25,13 @@ func moveWindow(windowName string, instance int, x int, y int, width int, height
 	fmt.Println("Not using instance:", instance)
 	repaint := 1 // TRUE
 
-	ret, _, err := showWindowProc.Call(hwnd, 9)
+	ret, _, err := showWindowProc.Call(hwnd[0], 9)
 	if ret == 0 {
 		return err
 	}
 
 	ret, _, err = moveWindowProc.Call(
-		hwnd,
+		hwnd[0],
 		uintptr(x),
 		uintptr(y),
 		uintptr(width),
@@ -42,14 +42,14 @@ func moveWindow(windowName string, instance int, x int, y int, width int, height
 		return err
 	}
 
-	bringWindowToTopProc.Call(hwnd)
-	setForegroundWindowProc.Call(hwnd)
+	bringWindowToTopProc.Call(hwnd[0])
+	setForegroundWindowProc.Call(hwnd[0])
 
 	fmt.Println("Window restored, moved, resized, and brought to the foreground.")
 	return nil
 }
 
-func getHWND(targetProcessName string) (uintptr, error) {
+func getHWND(targetProcessName string) ([]uintptr, error) {
 	user32DLL := syscall.NewLazyDLL("user32.dll")
 	kernel32DLL := syscall.NewLazyDLL("kernel32.dll")
 
@@ -62,7 +62,7 @@ func getHWND(targetProcessName string) (uintptr, error) {
 	closeHandleProc := kernel32DLL.NewProc("CloseHandle")
 
 	const processQueryLimitedInformation = 0x1000
-	var foundHWND uintptr
+	var foundHWNDs []uintptr
 	var callbackErr error
 
 	callback := syscall.NewCallback(func(hwnd uintptr, lparam uintptr) uintptr {
@@ -102,26 +102,25 @@ func getHWND(targetProcessName string) (uintptr, error) {
 		exePath := syscall.UTF16ToString(buf[:size])
 		exeName := strings.ToLower(filepath.Base(exePath))
 		if exeName == targetProcessName {
-			foundHWND = hwnd
-			return 0 // stop enumeration
+			foundHWNDs = append(foundHWNDs, hwnd)
 		}
 
 		return 1 // continue
 	})
 
 	ret, _, err := enumWindowsProc.Call(callback, 0)
-	if ret == 0 && foundHWND == 0 {
+	if ret == 0 && len(foundHWNDs) == 0 {
 		if err != syscall.Errno(0) {
 			callbackErr = err
 		}
 	}
 
-	if foundHWND == 0 {
+	if len(foundHWNDs) == 0 {
 		if callbackErr != nil {
-			return 0, fmt.Errorf("failed to find HWND for %s: %w", targetProcessName, callbackErr)
+			return nil, fmt.Errorf("failed to find HWND for %s: %w", targetProcessName, callbackErr)
 		}
-		return 0, fmt.Errorf("could not find an open window for %s", targetProcessName)
+		return nil, fmt.Errorf("could not find an open window for %s", targetProcessName)
 	}
 
-	return foundHWND, nil
+	return foundHWNDs, nil
 }

--- a/spec.md
+++ b/spec.md
@@ -15,32 +15,33 @@
 ## Command: Locate
 
 - [ ] `place locate process-name instance x y width height` should move the given instance of the process-name.exe window to location x, y and resize it to width x height
-- [ ] gets a list of windows of `process-name.exe`
+    - [x] gets a list of windows of `process-name.exe`
     - [x] as a start, get the first instance
-    - Can getHWND return a list of matches along with their HWND's?
-    - I'm hoping this list is already sorted in a sane way, so I can use the index as the "instance" number, which translates to "smallest number is the window opened the longest ago" (same order as when you hover over the taskbar and it shows previews)
-- [x] moves the correct window to `x, y`
-- [x] resizes the correct window to `width x height`
-- [ ] validates args don't do anything dangerous
-    - [x] process name
-        - [x] strips out whitespace (this seems unnecessary)
-        - [x] enforces not blank (also seems unnecessary)
-        - [x] enforces no "path characters"
-        - [x] enforces no "control characters"
-        - [x] strips out endings of `.exe`
-    - [ ] x, y, height, width
-        - [x] send through `stringconv.Atoi`, will error on non-int
-        - [x] enforce non-negative
-        - [x] enforce max value so it doesn't wrap around
-        - [ ] enforce maxima based on display size
-    - [x] instance
-        - [x] send through `stringconv.Atoi`, will error on non-int
-        - [x] enforce non-negative
-        - [x] enforce max value of `10`
-- [x] unminimizes the window first
-    - [x] must do this before moving/resizing, nothing happens if it's minimized
-    - [x] similar issue when maximized, as soon as you move it the old size returns
-    - restoring if not maximized or minimized doesn't seem to have any ill effects, but not 100% sure
+    - [ ] sorts list by create_date; is this possible?
+        - trying to achieve the same order that windows uses when you hover a taskbar item
+    - [ ] uses `instance` to choose which of the matching windows to move
+    - [x] moves the correct window to `x, y`
+    - [x] resizes the correct window to `width x height`
+    - [ ] validates args don't do anything dangerous
+        - [x] process name
+            - [x] strips out whitespace (this seems unnecessary)
+            - [x] enforces not blank (also seems unnecessary)
+            - [x] enforces no "path characters"
+            - [x] enforces no "control characters"
+            - [x] strips out endings of `.exe`
+        - [ ] x, y, height, width
+            - [x] send through `stringconv.Atoi`, will error on non-int
+            - [x] enforce non-negative
+            - [x] enforce max value so it doesn't wrap around
+            - [ ] enforce maxima based on display size
+        - [x] instance
+            - [x] send through `stringconv.Atoi`, will error on non-int
+            - [x] enforce non-negative
+            - [x] enforce max value of `10`
+    - [x] unminimizes the window first
+        - [x] must do this before moving/resizing, nothing happens if it's minimized
+        - [x] similar issue when maximized, as soon as you move it the old size returns
+        - restoring if not maximized or minimized doesn't seem to have any ill effects, but not 100% sure
 
 ## Command: Create
 


### PR DESCRIPTION
### Motivation
- The window lookup previously returned only the first matching handle which prevented operations on multiple windows from the same process.
- The intent is to collect every visible window handle whose executable name matches `targetProcessName` while preserving current behavior of acting on the first match.
- This enables future code to use or iterate over all matches while continuing to keep existing callers working.

### Description
- Changed `getHWND` signature from `func getHWND(targetProcessName string) (uintptr, error)` to `func getHWND(targetProcessName string) ([]uintptr, error)` and made it append all matching HWNDs into a `[]uintptr` slice in `move-window.go`.
- Updated the `moveWindow` function to accept the returned slice and use the first result at call sites by replacing `hwnd` with `hwnd[0]` when passing handles to Win32 APIs (`ShowWindow`, `MoveWindow`, `BringWindowToTop`, `SetForegroundWindow`).
- Preserved existing error behavior by returning an error when no matching windows are found.

### Testing
- Ran `go test ./...` which completed successfully (no test files in the module).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6a640234483208e6596ae921366c5)